### PR TITLE
Fixed for Safari - reducing new standards in favor of cross platformness

### DIFF
--- a/public/app/controllers/Quiz.js
+++ b/public/app/controllers/Quiz.js
@@ -1,8 +1,10 @@
 // Set-up new game
 app.controller('Quiz', function($scope, $http, config) {
-    var userId = config.userId || new URLSearchParams(window.location.search).get('uid') || 0;
-
-    $scope.Init = function(lang = "en") {
+    var urlParams = window.location.search.substring(1).split('=');
+    var uid = urlParams[1];
+    var userId = config.userId || uid || 0;
+    $scope.Init = function(lang) {
+        if(!lang) { lang = 'en'; }
         var request_new_game = {
             method: 'POST',
             url: config.API_URL + '/games/new/',


### PR DESCRIPTION
Removed the use of initializing vars on call - it's a ES5 new feature.
Removed URLSearchParams - not supported on old safari < 10